### PR TITLE
Add bspline property offset handling

### DIFF
--- a/sketch/gcs_wrapper.ts
+++ b/sketch/gcs_wrapper.ts
@@ -520,7 +520,9 @@ export class GcsWrapper {
                     if (!is_sketch_geometry(ref_primitive)) {
                         throw new Error(`Primitive #${val.o_id} (${ref_primitive.type}) is not supported to be referenced from a constraint.`);
                     }
-                    const param_addr = this.get_primitive_addr(val.o_id) + get_property_offset(ref_primitive.type, val.prop);
+                    const param_addr =
+                        this.get_primitive_addr(val.o_id) +
+                        get_property_offset(ref_primitive, val.prop);
                     add_constraint_args.push(param_addr);
                 }
             } else if (type === 'object_id' && typeof val === 'string') {


### PR DESCRIPTION
## Summary
- extend `SketchGeometryProperty` with bspline-specific keys
- list bspline offsets in `property_offsets`
- compute bspline offsets dynamically in `get_property_offset`
- update `gcs_wrapper` for new function signature

## Testing
- `npm test` *(fails: Failed to load planegcs_dist modules)*

------
https://chatgpt.com/codex/tasks/task_e_6852b2e419d88325be4bbc91cf8a464a