### PR TITLE
Add B-spline bindings

### DIFF
--- a/build-bindings/templates/gcs_system.cpp.njk
+++ b/build-bindings/templates/gcs_system.cpp.njk
@@ -328,6 +328,7 @@ class GcsSystem : System
             return a;   
         }
         
+        /* B-Spline geometry */
         BSpline make_bspline(
             int startx_i, int starty_i, int endx_i, int endy_i, vector<int> poles_xy_i,
             vector<int> weights_i, vector<int> knots_i, vector<int> mult, int degree, bool periodic

--- a/build-bindings/templates/gcs_system.ts.njk
+++ b/build-bindings/templates/gcs_system.ts.njk
@@ -47,6 +47,18 @@ export interface GcsSystem {
 {% for func in fn_ts_bindings %}
     {{ func.fname }}: ({{ func.args }}) => {{ func.return_type }};
 {%- endfor %}
+    /* B-Spline helpers */
+    make_bspline: (startx_i: number, starty_i: number, endx_i: number, endy_i: number,
+                   poles_xy_i: IntVector, weights_i: IntVector, knots_i: IntVector,
+                   mult: IntVector, degree: number, periodic: boolean) => BSpline;
+    add_constraint_tangent_at_bspline_knot: ( b: BSpline,  l: Line, knotindex: number,
+        tagId: number, driving: boolean, scale: number) => void;
+    add_constraint_point_on_bspline: ( p: Point,  b: BSpline, pointparam_param_i: number,
+        tagId: number, driving: boolean, scale: number) => void;
+    add_constraint_internal_alignment_bspline_control_point: ( b: BSpline, c: Circle,
+        poleindex: number, tag: number, driving: boolean, scale: number) => void;
+    add_constraint_internal_alignment_knot_point: ( b: BSpline,  p: Point,
+        knotindex: number, tagId: number, driving: boolean, scale: number) => void;
     delete: () => void;
 }
 

--- a/build-bindings/templates/gcs_system_mock.ts.njk
+++ b/build-bindings/templates/gcs_system_mock.ts.njk
@@ -26,7 +26,7 @@ import { {% for enum_name in import_enums %}{{ enum_name }}, {% endfor -%} } fro
 
 export class GcsSystemMock implements GcsSystem {
     {%- for func in fn_ts_bindings %}
-    {{ func.fname }}({{ func.args }}): {{ func.return_type }} { 
+    {{ func.fname }}({{ func.args }}): {{ func.return_type }} {
         {%- if func.return_type != 'void' %}
         // @ts-expect-error: return in mock can be undefined
         return undefined;
@@ -35,7 +35,39 @@ export class GcsSystemMock implements GcsSystem {
         {%- endif %}
     }
     {%- endfor %}
+    make_bspline(
+        startx_i: number, starty_i: number, endx_i: number, endy_i: number,
+        poles_xy_i: IntVector, weights_i: IntVector, knots_i: IntVector,
+        mult: IntVector, degree: number, periodic: boolean
+    ): BSpline {
+        // @ts-expect-error mock return
+        return undefined;
+    }
+    add_constraint_tangent_at_bspline_knot(
+        b: BSpline, l: Line, knotindex: number, tagId: number,
+        driving: boolean, scale: number
+    ): void {
+        return;
+    }
+    add_constraint_point_on_bspline(
+        p: Point, b: BSpline, pointparam_param_i: number,
+        tagId: number, driving: boolean, scale: number
+    ): void {
+        return;
+    }
+    add_constraint_internal_alignment_bspline_control_point(
+        b: BSpline, c: Circle, poleindex: number, tag: number,
+        driving: boolean, scale: number
+    ): void {
+        return;
+    }
+    add_constraint_internal_alignment_knot_point(
+        b: BSpline, p: Point, knotindex: number, tagId: number,
+        driving: boolean, scale: number
+    ): void {
+        return;
+    }
     delete(): void {
-        return; 
+        return;
     }
 }


### PR DESCRIPTION
## Summary
- expose B‑Spline helpers in the TypeScript bindings
- implement mock stubs for the new helper methods
- annotate B‑Spline creation in C++ template

## Testing
- `npm test` *(fails: TypeError: default is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_6852bc3086748325bede74f74092e0d2